### PR TITLE
Change player stats to use promises not callbacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-dota-api",
-  "version": "4.0.0",
+  "version": "3.1.1",
   "description": "A wrapper for the OpenDota API",
   "main": "./dotaPlayerApi.js",
   "author": "Alex Muench",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-dota-api",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "A wrapper for the OpenDota API",
   "main": "./dotaPlayerApi.js",
   "author": "Alex Muench",


### PR DESCRIPTION
This will break any previous uses of the library. Parameters are changed to no longer take a callback and all calls to the library must account for the fact that it now uses promises.